### PR TITLE
chore: update copyright year to 2021

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2020 Target Brands, Inc.
+   Copyright (c) 2021 Target Brands, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,37 @@
 # .github
-Default Vela community files 
 
-see [About Default Community Health Files](https://help.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file-for-your-organization#about-default-community-health-files) for more info
+[![license](https://img.shields.io/crates/l/gl.svg)](LICENSE)
+
+Default community files for Vela. See [About Default Community Health Files](https://help.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file-for-your-organization#about-default-community-health-files) for more info.
+
+> Vela is in active development and is a pre-release product. Please use at your own risk in production.
+>
+> Feel free to send us feedback at https://github.com/go-vela/community/issues/new.
+
+Vela is a Pipeline Automation (CI/CD) framework built on [Linux container](https://linuxcontainers.org/) technology written in [Golang](https://golang.org/).
+
+Vela uses a syntax similar to [Docker Compose](https://docs.docker.com/compose/) to define its configuration. This structure for repeated use, within the application, is called a pipeline and a single execution of a pipeline is referenced as a build.
+
+## Documentation
+
+For installation and usage, please [visit our user docs](https://go-vela.github.io/docs).
+
+## Contributing
+
+We are always welcome to new pull requests!
+
+Please see our [contributing](CONTRIBUTING.md) documentation for further instructions.
+
+## Support
+
+We are always here to help!
+
+Please see our [support](SUPPORT.md) documentation for further instructions.
+
+## Copyright and License
+
+```
+Copyright (c) 2021 Target Brands, Inc.
+```
+
+[Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
This is a general housekeeping task.

I updated the copyright statement in the `LICENSE` file:

```
Copyright (c) 2021 Target Brands, Inc. All rights reserved.
```

I also updated the `README` content to match what we have for other repos.